### PR TITLE
normalize header

### DIFF
--- a/src/integration/java/com/github/feroult/gapi/SpreadsheetAPITest.java
+++ b/src/integration/java/com/github/feroult/gapi/SpreadsheetAPITest.java
@@ -8,11 +8,13 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @Ignore
 public class SpreadsheetAPITest {
 
 	private final String[][] peopleTable = new String[][]{{"id", "name", "age"}, {"1", "John", "10"}, {"2", "Anne", "15"}};
+	private final String[][] projecTable = new String[][]{{"Project ID", "Project Name"}, {"123", "Project 1"}, {"321", "Project 2"}};
 
 	private GoogleAPI google;
 
@@ -75,6 +77,26 @@ public class SpreadsheetAPITest {
 			assertEquals("1", record.get("id"));
 			assertEquals("John", record.get("name"));
 			assertEquals("10", record.get("age"));
+
+		} finally {
+			google.drive().delete(key);
+		}
+	}
+
+	@Test
+	public void testNormalizeKeysAsMap() {
+		String key = google.drive().createSpreadsheet();
+
+		try {
+			google.spreadsheet(key).worksheet("xpto").batch(new MockTableBatch(projecTable));
+
+			List<Map<String, String>> records = google.spreadsheet(key).worksheet("xpto").asMap();
+
+			Map<String, String> record = records.get(0);
+			assertNull(record.get("Project ID"));
+			assertNull(record.get("Project Name"));
+			assertEquals("123", record.get("projectid"));
+			assertEquals("Project 1", record.get("projectname"));
 
 		} finally {
 			google.drive().delete(key);

--- a/src/main/java/com/github/feroult/gapi/spreadsheet/SpreadsheetAPIImpl.java
+++ b/src/main/java/com/github/feroult/gapi/spreadsheet/SpreadsheetAPIImpl.java
@@ -226,18 +226,18 @@ class SpreadsheetAPIImpl implements SpreadsheetAPI {
 		}
 
 		List<List<Object>> body = response.getValues();
-		List<Object> header = body.get(0);
+		List<String> header = convertObjectToString(body.get(0));
 		body.remove(0);
 		return listToMap(header, body);
 	}
 
-	private List<Map<String, String>> listToMap(List<Object> header, List<List<Object>> body) {
+	private List<Map<String, String>> listToMap(List<String> header, List<List<Object>> body) {
 		List<Map<String, String>> ret = new ArrayList<>();
 
 		if (body.isEmpty()) {
-			for (Object item : header) {
+			for (String item : header) {
 				Map<String, String> row = new HashMap<>();
-				row.put(item.toString(), "");
+				row.put(item, "");
 
 				ret.add(row);
 			}
@@ -249,11 +249,21 @@ class SpreadsheetAPIImpl implements SpreadsheetAPI {
 					if (objects.size() - 1 >= j) {
 						value = objects.get(j).toString();
 					}
-					row.put(header.get(j).toString(), value);
+					row.put(header.get(j), value);
 				}
 				ret.add(row);
 			}
 		}
 		return ret;
+	}
+
+	private List<String> convertObjectToString(List<Object> objects) {
+		List<String> strings = new ArrayList<>();
+		objects.forEach(obj -> strings.add(normalize(obj.toString())));
+		return strings;
+	}
+
+	private String normalize(String str) {
+		return str.replace(" ", "").toLowerCase();
 	}
 }


### PR DESCRIPTION
### Problema
Na versão antiga do GAPI, o gdata normalizava o valor dos headers, antes de passar para map.

### Solução
Criar um método para normalizar os headers na nova versão.